### PR TITLE
fix/address-linter-warnings-and-update-cfg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.23.x'
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '1.23.x'
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: v1.64
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,15 +84,13 @@ linters-settings:
     ignore-tests: true 
     match-constant: true 
    
+  # TODO: consider exanding the amount of checks
   gocritic: 
     disable-all: true
     enabled-checks:
       - nestingReduce
       - unnamedResult
       - ruleguard
-    enabled-tags:
-      - diagnostic
-      - performance
 
   godot:
     scope: toplevel

--- a/config.go
+++ b/config.go
@@ -301,7 +301,6 @@ type ByteSize struct {
 
 // MarshalJSON marshals the Duration to JSON.
 func (b *ByteSize) MarshalJSON() ([]byte, error) {
-
 	bs := b.Value
 	if bs == 0 {
 		bs = 1024 // Default to 1k


### PR DESCRIPTION
This PR fixes some linter errors and also updates the linter settings to disable many gocritic checks. Will spend some time looking into gocritic checks in more detail in the future.